### PR TITLE
cellular_3gpp_api: use QGMR on non-diablos

### DIFF
--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1980,7 +1980,12 @@ CellularError_t Cellular_CommonGetModemInfo( CellularHandle_t cellularHandle,
     CellularAtReq_t atReqGetModelId = { 0 };
     CellularAtReq_t atReqGetManufactureId = { 0 };
 
+#if GW_HW_REV < 40
+    // hack with this #if but we'll move away from this lib soon enough
+    atReqGetFirmwareVersion.pAtCmd = "AT+QGMR";
+#else
     atReqGetFirmwareVersion.pAtCmd = "AT+CGMR";
+#endif
     atReqGetFirmwareVersion.atCmdType = CELLULAR_AT_WO_PREFIX;
     atReqGetFirmwareVersion.pAtRspPrefix = NULL;
     atReqGetFirmwareVersion.respCallback = _Cellular_RecvFuncGetFirmwareVersion;


### PR DESCRIPTION
This is very much a hack but we're moving off this lib soon enough. Gives us the full modem fw string